### PR TITLE
Fixed the perceivers github issue# 34

### DIFF
--- a/perceivers/pkg/annotations/image.go
+++ b/perceivers/pkg/annotations/image.go
@@ -40,7 +40,7 @@ func CreateImageLabels(obj interface{}, name string, count int) map[string]strin
 	if len(name) > 0 {
 		imagePostfix = fmt.Sprintf("%d", count)
 		name = strings.Replace(name, "/", ".", -1)
-		// If any image is from private registry, it might tagged with port number
+		// some images end up having 'image:port' format, which breaks the req'd regex format. 
 		name = strings.Replace(name, ":", ".", -1)
 		labels[fmt.Sprintf("com.blackducksoftware.image%d", count)] = strings.Replace(name, "/", ".", -1)
 	}

--- a/perceivers/pkg/annotations/image.go
+++ b/perceivers/pkg/annotations/image.go
@@ -39,6 +39,9 @@ func CreateImageLabels(obj interface{}, name string, count int) map[string]strin
 
 	if len(name) > 0 {
 		imagePostfix = fmt.Sprintf("%d", count)
+		name = strings.Replace(name, "/", ".", -1)
+		// If any image is from private registry, it might tagged with port number
+		name = strings.Replace(name, ":", ".", -1)
 		labels[fmt.Sprintf("com.blackducksoftware.image%d", count)] = strings.Replace(name, "/", ".", -1)
 	}
 	labels[fmt.Sprintf("com.blackducksoftware.image%s.policy-violations", imagePostfix)] = fmt.Sprintf("%d", imageData.GetPolicyViolationCount())


### PR DESCRIPTION
If any image is from private registry, it might tagged with port number and hence replacing : with .