### PR TITLE
Handle label values longer than 63 characters. 

### DIFF
--- a/perceivers/pkg/annotations/image.go
+++ b/perceivers/pkg/annotations/image.go
@@ -39,10 +39,7 @@ func CreateImageLabels(obj interface{}, name string, count int) map[string]strin
 
 	if len(name) > 0 {
 		imagePostfix = fmt.Sprintf("%d", count)
-		name = strings.Replace(name, "/", ".", -1)
-		// some images end up having 'image:port' format, which breaks the req'd regex format. 
-		name = strings.Replace(name, ":", ".", -1)
-		labels[fmt.Sprintf("com.blackducksoftware.image%d", count)] = name
+		labels[fmt.Sprintf("com.blackducksoftware.image%d", count)] = ShortenLabelContent(name)
 	}
 	labels[fmt.Sprintf("com.blackducksoftware.image%s.policy-violations", imagePostfix)] = fmt.Sprintf("%d", imageData.GetPolicyViolationCount())
 	labels[fmt.Sprintf("com.blackducksoftware.image%s.has-policy-violations", imagePostfix)] = fmt.Sprintf("%t", imageData.HasPolicyViolations())
@@ -76,4 +73,31 @@ func CreateImageAnnotations(obj interface{}, name string, count int) map[string]
 	newAnnotations[fmt.Sprintf("%s%s/policy.blackduck", imagePrefix, ImageAnnotationPrefix)] = policyAnnotations.AsString()
 
 	return newAnnotations
+}
+
+// ShortenLabelContent will ensure the data is less than the 63 character limit and doesn't contain
+// any characters that are not allowed
+func ShortenLabelContent(data string) string {
+	newData := RemoveRegistryInfo(data)
+
+	// Label values can not be longer than 63 characters
+	if len(newData) > 63 {
+		newData = newData[0:63]
+	}
+
+	return newData
+}
+
+// RemoveRegistryInfo will take a string and return a string that removes any registry name information
+// and replaces all / with .
+func RemoveRegistryInfo(d string) string {
+	s := strings.Split(d, "/")
+
+	// If the data includes a . or : before the first / then that string is most likely
+	// a registry name.  Remove it because it could make the data too long and
+	// truncate useful information
+	if strings.Contains(s[0], ".") || strings.Contains(s[0], ":") {
+		s = s[1:]
+	}
+	return strings.Join(s, ".")
 }

--- a/perceivers/pkg/annotations/image_test.go
+++ b/perceivers/pkg/annotations/image_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright (C) 2018 Synopsys, Inc.
+
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package annotations
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/blackducksoftware/perceivers/pkg/annotations"
+)
+
+func TestCreateImageLabels(t *testing.T) {
+	registry := "registry.name.com"
+	registryWithPort := "registry:1000"
+	shortImageName := "short/imagename"
+	longImageName := "this/isareally/long/imagename/that/islonger/than/allowed/63characters"
+
+	testcases := []struct {
+		description string
+		imageName   string
+		expected    map[string]string
+	}{
+		{
+			description: "image name includes a registry, but name is under than 63 characters",
+			imageName:   registry + "/" + shortImageName,
+			expected:    map[string]string{"com.blackducksoftware.image0": RemoveRegistryInfo(shortImageName)},
+		},
+		{
+			description: "image name includes a registry with a port, but name is under than 63 characters",
+			imageName:   registryWithPort + "/" + shortImageName,
+			expected:    map[string]string{"com.blackducksoftware.image0": RemoveRegistryInfo(shortImageName)},
+		},
+		{
+			description: "image name includes a registry, and name is longer than 63 characters",
+			imageName:   registry + "/" + longImageName,
+			expected:    map[string]string{"com.blackducksoftware.image0": RemoveRegistryInfo(longImageName[0:63])},
+		},
+		{
+			description: "image name is longer than 63 characters",
+			imageName:   longImageName,
+			expected:    map[string]string{"com.blackducksoftware.image0": RemoveRegistryInfo(longImageName[0:63])},
+		},
+		{
+			description: "image name is shorter than 63 characters",
+			imageName:   shortImageName,
+			expected:    map[string]string{"com.blackducksoftware.image0": RemoveRegistryInfo(shortImageName)},
+		},
+	}
+
+	for _, tc := range testcases {
+		obj := annotations.NewImageAnnotationData(2, 10, "NOT_IN_VIOLATION", "http://url/ofthe/hub/scan", "1.1.1", "1.1.1")
+		result := CreateImageLabels(obj, tc.imageName, 0)
+		for k, v := range tc.expected {
+			if val, ok := result[k]; !ok {
+				t.Errorf("[%s] created labels missing key %s, labels %v", tc.description, k, result)
+			} else {
+				if strings.Compare(v, val) != 0 {
+					t.Errorf("[%s] created label value %s differs from expected %s", tc.description, val, v)
+				}
+				if len(val) > 63 {
+					t.Errorf("[%s] key %s has value %s, which is longer than 62 characters", tc.description, k, val)
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
If there is a registry in the string, remove it #23